### PR TITLE
JumpToDependency: Support a click position to find the import

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -20,6 +20,8 @@ program
 
   // Feature flags
   .option('--lookup', 'perform a partial lookup for the jump to dependency feature')
+  .option('--lookup-position', 'jump to dependency: location of the clicked character of the target')
+
   .option('--find-dependents', 'get the dependents of the current file')
   .option('--find-drivers', 'get the driver scripts relevant to current file')
   .option('--find-callers', 'get the scripts calling the given function name')

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,6 @@
 var Config = require('./Config');
 var getPath = require('./getPath');
+var getClickedImport = require('./getClickedImport');
 
 var cabinet = require('filing-cabinet');
 var findDependents = require('dependents');
@@ -16,10 +17,9 @@ module.exports = function(program) {
 
   // Useful for consumers like Atom
   if (program.debug) {
+    // TODO: Try setting process.env.DEBUG instead
     debug = console.log.bind(console);
   }
-
-  debug('given program options', program);
 
   var config;
   try {
@@ -44,16 +44,16 @@ module.exports = function(program) {
   debug('command options', options);
 
   if (program.lookup) {
-    options.target = program.args[0].replace(/["|'|;]/g, '');
-    debug('performing a lookup');
+    if (!program.lookupPosition) {
+      options.partial = program.args[0].replace(/["|'|;]/g, '');
+    } else {
+      debug('given a lookup location: ', program.lookupPosition);
+      options.partial = getClickedImport(program.args[0], Number(program.lookupPosition));
+    }
 
-    var result = cabinet({
-      partial: options.target,
-      filename: options.filename,
-      directory: options.directory,
-      config: options.config,
-      webpackConfig: options.webpackConfig
-    });
+    debug('performing a lookup with options: ', options);
+
+    var result = cabinet(options);
 
     debug('lookup result: ' + result);
     deferred.resolve(result);
@@ -124,6 +124,9 @@ module.exports = function(program) {
 
   } else if (program.getConfig) {
     deferred.resolve(config.toJSON());
+
+  } else {
+    deferred.reject('No valid command given');
   }
 
   return deferred.promise;

--- a/lib/getClickedImport.js
+++ b/lib/getClickedImport.js
@@ -1,0 +1,28 @@
+module.exports = function(input, clickPosition) {
+  var stringPattern = /[\'"]{1}([^"\']*)[\'"]{1}/g;
+  // Ignores the first word on a line since that's usually a pragma
+  var wordPattern = /[\s]{1}([^\s]*)/g;
+
+  var hasString = stringPattern.test(input);
+
+  return getClickedPattern(hasString ? stringPattern : wordPattern, input, clickPosition);
+};
+
+function getClickedPattern(pattern, input, clickedPosition) {
+  var match;
+
+  while (match = pattern.exec(input)) {
+    if (matchContainsPosition(match, clickedPosition)) {
+      return match[1];
+    }
+  }
+
+  return pattern.exec(input)[1];
+}
+
+function matchContainsPosition(match, position) {
+  var whole = match[0];
+  var startIndex = match.index;
+  var endIndex = startIndex + whole.length - 1;
+  return startIndex <= position && position <= endIndex;
+}

--- a/test/features/jumpToDependency.js
+++ b/test/features/jumpToDependency.js
@@ -15,6 +15,36 @@ describe('partial lookup', function() {
     };
   });
 
+  describe('positional lookup', function() {
+    describe('when given a line of text and a clicked position within that text', function() {
+      it('finds and resolves the relevant import', function() {
+        const directory = `${this._fixturePath}/javascript/es6`;
+
+        return this._run({
+          lookupPosition: 18,
+          filename: `${directory}/index.js`,
+          args: ['import bar from \'./bar\';']
+        }).then(result => {
+          assert.equal(result, `${directory}/bar.js`);
+        });
+      });
+    });
+
+    describe('when given a line of padded text and a clicked position within that text', function() {
+      it('finds and resolves the relevant import', function() {
+        const directory = `${this._fixturePath}/javascript/es6`;
+
+        return this._run({
+          lookupPosition: 23,
+          filename: `${directory}/index.js`,
+          args: ['      import bar from \'./bar\';']
+        }).then(result => {
+          assert.equal(result, `${directory}/bar.js`);
+        });
+      });
+    });
+  });
+
   describe('sass', function() {
     beforeEach(function() {
       this._directory = `${this._fixturePath}/sass`;

--- a/test/lib/cli.js
+++ b/test/lib/cli.js
@@ -15,4 +15,13 @@ describe('lib/cli', function() {
       done();
     });
   });
+
+  it('rejects if no supported command was supplied', function(done) {
+    cli({
+      filename: `${this._fixturePath}/javascript/es6/index.js`
+    }).catch(message => {
+      assert.equal(message, 'No valid command given');
+      done();
+    });
+  });
 });

--- a/test/lib/getClickedImport.js
+++ b/test/lib/getClickedImport.js
@@ -1,0 +1,127 @@
+import getClickedImport from '../../lib/getClickedImport';
+import assert from 'assert';
+import path from 'path';
+
+describe('lib/getClickedImport', function() {
+  beforeEach(function() {
+    this._fixturePath = path.resolve(__dirname, '../fixtures');
+  });
+
+  describe('when given a lookup position', function() {
+    describe('for a line with a single string', function() {
+      beforeEach(function() {
+        this._fixture = 'import {SelectListView} from "atom-space-pen-views";';
+      });
+
+      describe('and the position collides with the start of the string', function() {
+        it('returns the quoteless string', function() {
+          const result = getClickedImport(this._fixture, 29);
+          assert.equal(result, 'atom-space-pen-views');
+        });
+      });
+
+      describe('and the position collides with the end of the string', function() {
+        it('returns the quoteless string', function() {
+          const result = getClickedImport(this._fixture, 50);
+          assert.equal(result, 'atom-space-pen-views');
+        });
+      });
+
+      describe('and the position collides within the string', function() {
+        it('returns the quoteless string', function() {
+          const result = getClickedImport(this._fixture, 32);
+          assert.equal(result, 'atom-space-pen-views');
+        });
+      });
+
+      describe('and the position does not collide', function() {
+        it('returns the quoteless string anyway', function() {
+          const result = getClickedImport(this._fixture, 12);
+          assert.equal(result, 'atom-space-pen-views');
+        });
+      });
+
+      describe('and the position is negative', function() {
+        it('returns the quoteless string anyway', function() {
+          const result = getClickedImport(this._fixture, -1);
+          assert.equal(result, 'atom-space-pen-views');
+        });
+      });
+
+      describe('and the position exceeds the length of the string', function() {
+        it('returns the quoteless string anyway', function() {
+          const result = getClickedImport(this._fixture, 100);
+          assert.equal(result, 'atom-space-pen-views');
+        });
+      });
+    });
+
+    describe('for a line with multiple strings', function() {
+      beforeEach(function() {
+        this._fixture = 'define(["foo", "bar"], function(foo, bar) {';
+      });
+
+      describe('and the position collides with a string', function() {
+        it('returns the quoteless string', function() {
+          const result = getClickedImport(this._fixture, 16);
+          assert.equal(result, 'bar');
+        });
+      });
+
+      describe('and the position does not collide', function() {
+        it('returns the first string', function() {
+          const result = getClickedImport(this._fixture, 50);
+          assert.equal(result, 'foo');
+        });
+      });
+
+      describe('and the position is negative', function() {
+        it('returns the first string', function() {
+          const result = getClickedImport(this._fixture, -1);
+          assert.equal(result, 'foo');
+        });
+      });
+
+      describe('and the position exceeds the length of the string', function() {
+        it('returns the first string', function() {
+          const result = getClickedImport(this._fixture, 100);
+          assert.equal(result, 'foo');
+        });
+      });
+    });
+
+    describe('for a line with no strings but space-delimited words', function() {
+      beforeEach(function() {
+        this._fixture = '@import styles.sass';
+      });
+
+      describe('and the position collides with the start of the word', function() {
+        it('returns the word', function() {
+          const result = getClickedImport(this._fixture, 9);
+          assert.equal(result, 'styles.sass');
+        });
+      });
+
+      describe('and the position collides with the end of the word', function() {
+        it('returns the word', function() {
+          const result = getClickedImport(this._fixture, 19);
+          assert.equal(result, 'styles.sass');
+        });
+      });
+
+      describe('and the position collides within the word', function() {
+        it('returns the word', function() {
+          const result = getClickedImport(this._fixture, 11);
+          assert.equal(result, 'styles.sass');
+        });
+      });
+
+      describe('and the position does not collide', function() {
+        it('returns the first space-surrounded string', function() {
+          const result = getClickedImport(this._fixture, 50);
+          assert.equal(result, 'styles.sass');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Consumers shouldn't have to find the import, they only need to
supply the relevant line of text and the index of the clicked char.
We'll find the import that collides with the click or provide a default.

Fixes #41
Fixes #42
Ref https://github.com/dependents/atom-dependents/issues/2
